### PR TITLE
Ensure that FlexDashboard.init() is the very last thing executed in the document

### DIFF
--- a/inst/rmarkdown/templates/flex_dashboard/resources/default.html
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/default.html
@@ -98,10 +98,6 @@ $body$
 
 </div>
 
-$for(include-after)$
-$include-after$
-$endfor$
-
 <script>
 
 $$(document).ready(function () {
@@ -119,6 +115,10 @@ $endif$
 
 });
 </script>
+
+$for(include-after)$
+$include-after$
+$endfor$
 
 </body>
 </html>


### PR DESCRIPTION
Eliminates problems with jquery wrap and wrapInner preventing the execution of embedded script tags.

Should address these issues:

- https://github.com/rstudio/flexdashboard/issues/29
- https://github.com/rstudio/flexdashboard/issues/48

Could folks on this thread install the branch to verify that the fix works:

```r
devtools::install_github("rstudio/flexdashboard", ref="bugfix/dashboard-init-after-body")
```