### PR TITLE
support for 'global' chunk label that behaves like shiny 'global.R'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ Authors@R: c(
 URL: http://rmarkdown.rstudio.com/flexdashboard
 BugReports: https://github.com/rstudio/flexdashboard/issues
 Depends: R (>= 3.0.2)
-Imports: tools, jsonlite, htmltools, knitr (>= 1.13), htmlwidgets (>= 0.6), rmarkdown (>= 1.0), shiny (>= 0.13)
+Imports: tools, jsonlite, htmltools, evaluate (>= 0.8), knitr (>= 1.13), htmlwidgets (>= 0.6), rmarkdown (>= 1.0), shiny (>= 0.13)
 Suggests: testthat
 LazyData: TRUE
 License: MIT + file LICENSE

--- a/R/flex_dashboard.R
+++ b/R/flex_dashboard.R
@@ -286,6 +286,8 @@ flex_dashboard <- function(fig_width = 6.0,
         if (!code %in% .globals$evaluated_global_chunks) {
           .globals$evaluated_global_chunks <- c(.globals$evaluated_global_chunks, code)
           evaluate::evaluate(code, envir = globalenv(), ...)
+        } else {
+          list()
         }
         # delegate to standard evaluate for everything else
       } else {

--- a/R/flex_dashboard.R
+++ b/R/flex_dashboard.R
@@ -283,6 +283,7 @@ flex_dashboard <- function(fig_width = 6.0,
       if (identical(chunk_options$label, "global")) {
         # evaluate the global chunk for this source file if it hasn't
         # been evaluated already
+        code <- paste(code, collapse = '\n')
         if (!code %in% .globals$evaluated_global_chunks) {
           .globals$evaluated_global_chunks <- c(.globals$evaluated_global_chunks, code)
           evaluate::evaluate(code, envir = globalenv(), ...)

--- a/R/flex_dashboard.R
+++ b/R/flex_dashboard.R
@@ -266,21 +266,9 @@ flex_dashboard <- function(fig_width = 6.0,
   #  special handling of 'global' chunk within runtime: shiny
   if (!is.null(shiny::getDefaultReactiveDomain())) {
 
-    # options hook to (a) capture the chunk options for inspection below and
-    # (b) to ensure that 'global' chunks are not displayed in the document
-    chunk_options <- list()
-    knitr::opts_hooks$set(include = function(options) {
-      chunk_options <<- options
-      if (identical(chunk_options$label, "global")) {
-        options$echo <- FALSE
-        options$include <- FALSE
-      }
-      options
-    })
-
     # evaluate the 'global' chunk only once, and in the global environment
     knitr::knit_hooks$set(evaluate = function(code, envir, ...) {
-      if (identical(chunk_options$label, "global")) {
+      if (identical(knitr::opts_current$get("label"), "global")) {
         # evaluate the global chunk for this source file if it hasn't
         # been evaluated already (flatten to code_string so the lookups
         # work correctly for multi-line strings)
@@ -298,7 +286,7 @@ flex_dashboard <- function(fig_width = 6.0,
       }
     })
 
-    # cleanup evaluated flag on reactive domain ended
+    # cleanup evaluated cache on reactive domain ended
     shiny::onReactiveDomainEnded(shiny::getDefaultReactiveDomain(), function() {
       .globals$evaluated_global_chunks <- character()
     })

--- a/R/flex_dashboard.R
+++ b/R/flex_dashboard.R
@@ -282,10 +282,12 @@ flex_dashboard <- function(fig_width = 6.0,
     knitr::knit_hooks$set(evaluate = function(code, envir, ...) {
       if (identical(chunk_options$label, "global")) {
         # evaluate the global chunk for this source file if it hasn't
-        # been evaluated already
-        code <- paste(code, collapse = '\n')
-        if (!code %in% .globals$evaluated_global_chunks) {
-          .globals$evaluated_global_chunks <- c(.globals$evaluated_global_chunks, code)
+        # been evaluated already (flatten to code_string so the lookups
+        # work correctly for multi-line strings)
+        code_string <- paste(code, collapse = '\n')
+        if (!code_string %in% .globals$evaluated_global_chunks) {
+          .globals$evaluated_global_chunks <-
+                          c(.globals$evaluated_global_chunks, code_string)
           evaluate::evaluate(code, envir = globalenv(), ...)
         } else {
           list()

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -4,7 +4,7 @@ flexdashboard 0.4 (unreleased)
 
 - Special 'global' chunk label for runtime: shiny which designates
   a chunk to be run once and only once in the global environment
-  (startup performanceimprovement for multi-user shiny flexdashboards)
+  (startup performance improvement for multi-user shiny flexdashboards)
 
 
 flexdashboard 0.3

--- a/inst/NEWS
+++ b/inst/NEWS
@@ -1,4 +1,12 @@
 
+flexdashboard 0.4 (unreleased)
+-----------------------------------------------------------------------
+
+- Special 'global' chunk label for runtime: shiny which designates
+  a chunk to be run once and only once in the global environment
+  (startup performanceimprovement for multi-user shiny flexdashboards)
+
+
 flexdashboard 0.3
 -----------------------------------------------------------------------
 


### PR DESCRIPTION
Shiny-based flexdashboards with multiple users can currently specify expensive one-time startup operations using an external global.R file. This PR enables this code to be directly incorporated into the Rmd file using a special chunk with the label 'global'.

The 'global' chunk's evaluation is customized using a kntir evaluate hook as follows:

1) It's evaluated in the global environment;

2) The actual code evaluated it tracked to ensure that the code is never evaluated more than once (i.e. subsequent users in a multi-user application benefit from the one time initialization).

The motivation for this PR is largely to support documenting best practices for performance in single-file examples (we have many of them now their code can be inspected via the prominent "Source Code" button in the top-right of the dashboard).

@jcheng5 This makes use of reactive domain APIs which I want to be sure I got right. The main thing is that at the end of the Shiny session I clear my list of "previously evaluated" global chunks (this is intended to support the scenario of multiple flexdashboards served as a website).

@yihui Let me know if any of my use of knitr hooks looks problematic.

@jmcphers 
