### PR TITLE
Use the html4 output format instead of the default html5 in Pandoc 2.0

### DIFF
--- a/R/flex_dashboard.R
+++ b/R/flex_dashboard.R
@@ -414,9 +414,10 @@ flex_dashboard <- function(fig_width = 6.0,
   # return format
   output_format(
     knitr = knitr_options,
-    pandoc = pandoc_options(to = "html",
+    pandoc = pandoc_options(to = "html4",
                             from = rmarkdown_format(md_extensions),
-                            args = args),
+                            args = args,
+                            ext = ".html"),
     keep_md = FALSE,
     clean_supporting = self_contained,
     pre_knit = pre_knit,


### PR DESCRIPTION
Fixes #149.

Basically Pandoc 2.0 starts to default to `html5` when the output format is the ambiguous `html` (previously it was `html4`), and the consequence is that the section divs actually use the `<section>` tag instead of `<div>`. See https://groups.google.com/forum/#!topic/pandoc-discuss/d-d07z2iHJs for more information.

I have compared the output with this PR + Pandoc 2.0 against Pandoc 1.19, and the output files seem to be identical.