### PR TITLE
add option for navbar-default

### DIFF
--- a/inst/rmarkdown/templates/flex_dashboard/resources/default.html
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/default.html
@@ -52,7 +52,7 @@ $endfor$
 
 <body>
 
-<div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
+<div class="navbar navbar-$if(navbar_default)$default$else$inverse$endif$ navbar-fixed-top" role="navigation">
 <div class="container-fluid">
 <div class="navbar-header">
 


### PR DESCRIPTION
this adds the option to render the dashboard with either a navbar-inverse (the default) or navbar-default by setting navbar_default = TRUE in the top-level of the frontmatter