### PR TITLE
fix unicode in navbar, closes #125

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,8 +1,11 @@
 # return a string as a tempfile
 as_tmpfile <- function(str) {
   if (length(str) > 0) {
+    str <- enc2utf8(str)
     str_tmpfile <- tempfile("rmarkdown-str", fileext = ".html")
-    writeLines(str, str_tmpfile, useBytes = TRUE)
+    con <- file(str_tmpfile, open = "w+", encoding = "native.enc")
+    writeLines(str, con = con, useBytes = TRUE)
+    close(con)
     str_tmpfile
   } else {
     NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,7 +2,7 @@
 as_tmpfile <- function(str) {
   if (length(str) > 0) {
     str_tmpfile <- tempfile("rmarkdown-str", fileext = ".html")
-    writeLines(str, str_tmpfile)
+    writeLines(str, str_tmpfile, useBytes = TRUE)
     str_tmpfile
   } else {
     NULL


### PR DESCRIPTION
This ought to fix #125, i.e. that navbar links do not show up or stop pandoc when they contain unicode characters. The problem is that `writeLines` in `as_tmpfile` writes the `str_tmpfile` in the native encoding, but pandoc expects it to be "UTF-8". (`as_tmpfile` is (only) called by `pandoc_navbar_args`).

Following @kevinushey's [lead](https://kevinushey.github.io/blog/2018/02/21/string-encoding-and-r/) here to ensure that `as_tmpfile` writes really writes in UTF-8 encoding. 