### PR TITLE
escape code when embed in case of html entities

### DIFF
--- a/R/flex_dashboard.R
+++ b/R/flex_dashboard.R
@@ -464,6 +464,9 @@ source_code_embed_args <- function(source_file) {
   # embed it
   if (length(code) > 0) {
 
+    # escape in case there is html in code
+    code <- htmlEscape(code)
+
     # ensure we don't start with an emtpy line
     code[[1]] <- paste0(
       '<pre class="line-numbers"><code class="language-r">',


### PR DESCRIPTION
This fixes #227 

If `source_code: embed`, the code part is HTML escaped using `htmltools::htmlEscape` before being included in `pre` and `code` tag. 
As Rmarkdown code could be composed of some html code too, this is useful so that pandoc does not try to interpret as html and throw an error.

I did not add tests as I am not sure what the way to do it here (only one test file)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rstudio/flexdashboard/228)
<!-- Reviewable:end -->
