### PR TITLE
Feature/resize_reload

### DIFF
--- a/R/flex_dashboard.R
+++ b/R/flex_dashboard.R
@@ -69,6 +69,10 @@
 #'@param devel Enable development mode (used for development of the format
 #'  itself, not useful for users of the format).
 #'
+#'@param auto_reload Disable the auto-reloading behavior when the window is resized.
+#' Useful when debugging large flexdashboard applications and this functionality
+#' is not needed.
+#'
 #'@param ... Unused
 #'
 #'@details See the flexdashboard website for additional documentation:
@@ -114,6 +118,7 @@ flex_dashboard <- function(fig_width = 6.0,
                            md_extensions = NULL,
                            pandoc_args = NULL,
                            devel = FALSE,
+                           auto_reload = TRUE,
                            ...) {
 
   # manage list of exit_actions (backing out changes to knitr options)
@@ -162,6 +167,11 @@ flex_dashboard <- function(fig_width = 6.0,
     theme <- "cosmo"
   else if (identical(theme, "bootstrap"))
     theme <- "default"
+
+  # resolve auto_reload
+  if (auto_reload == 'no' | grepl("fa?l?s?e?", auto_reload, ignore.case = T))
+    auto_reload <- F
+  else auto_reload <- T
 
   # determine knitr options
   knitr_options <- knitr_options_html(fig_width = fig_width,
@@ -353,6 +363,7 @@ flex_dashboard <- function(fig_width = 6.0,
        paste0('    defaultFigHeight: ', figSizePixels(fig_height), ','),
        paste0('    defaultFigWidthMobile: ', figSizePixels(fig_mobile[[1]]), ','),
        paste0('    defaultFigHeightMobile: ', figSizePixels(fig_mobile[[2]])),
+       paste0('    auto_reload: ', ifelse(auto_reload,'true','false'), ','),
        '  });',
        '});',
        '</script>'

--- a/R/flex_dashboard.R
+++ b/R/flex_dashboard.R
@@ -69,7 +69,7 @@
 #'@param devel Enable development mode (used for development of the format
 #'  itself, not useful for users of the format).
 #'
-#'@param auto_reload Disable the auto-reloading behavior when the window is resized.
+#'@param resize_reload Disable the auto-reloading behavior when the window is resized.
 #' Useful when debugging large flexdashboard applications and this functionality
 #' is not needed.
 #'
@@ -118,7 +118,7 @@ flex_dashboard <- function(fig_width = 6.0,
                            md_extensions = NULL,
                            pandoc_args = NULL,
                            devel = FALSE,
-                           auto_reload = TRUE,
+                           resize_reload = TRUE,
                            ...) {
 
   # manage list of exit_actions (backing out changes to knitr options)
@@ -169,9 +169,10 @@ flex_dashboard <- function(fig_width = 6.0,
     theme <- "default"
 
   # resolve auto_reload
-  if (auto_reload == 'no' | grepl("fa?l?s?e?", auto_reload, ignore.case = T))
-    auto_reload <- F
-  else auto_reload <- T
+  if (resize_reload == 'no' | grepl("fa?l?s?e?", resize_reload, ignore.case = T))
+    resize_reload <- F
+  else
+    resize_reload <- T
 
   # determine knitr options
   knitr_options <- knitr_options_html(fig_width = fig_width,
@@ -363,7 +364,7 @@ flex_dashboard <- function(fig_width = 6.0,
        paste0('    defaultFigHeight: ', figSizePixels(fig_height), ','),
        paste0('    defaultFigWidthMobile: ', figSizePixels(fig_mobile[[1]]), ','),
        paste0('    defaultFigHeightMobile: ', figSizePixels(fig_mobile[[2]])),
-       paste0('    auto_reload: ', ifelse(auto_reload,'true','false'), ','),
+       paste0('    resize_reload: ', ifelse(resize_reload,'true','false'), ','),
        '  });',
        '});',
        '</script>'

--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
@@ -19,7 +19,7 @@ var FlexDashboard = (function () {
       defaultFigHeightMobile: 461,
       isMobile: false,
       isPortrait: false,
-      auto_reload: true
+      resize_reload: true
     });
   };
 
@@ -139,16 +139,17 @@ var FlexDashboard = (function () {
     initPrismHighlighting();
 
     // record mobile and orientation state then register a handler
-    // to refresh if auto_reload is set to true and it changes
+    // to refresh if resize_reload is set to true and it changes
     _options.isMobile = isMobilePhone();
     _options.isPortrait = isPortrait();
-    $(window).on('resize', function() {
-      if ((_options.isMobile !== isMobilePhone() && _options.auto_reload) ||
-          (_options.isPortrait !== isPortrait() && _options.auto_reload)) {
-        window.location.reload();
-      }
-    });
-
+    if (_options.resize_reload) {
+      $(window).on('resize', function() {
+        if (_options.isMobile !== isMobilePhone() ||
+            _options.isPortrait !== isPortrait()) {
+          window.location.reload();
+        }
+      });
+    }
     // trigger layoutcomplete event
     dashboardContainer.trigger('flexdashboard:layoutcomplete');
   }

--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
@@ -18,7 +18,8 @@ var FlexDashboard = (function () {
       defaultFigWidthMobile: 360,
       defaultFigHeightMobile: 461,
       isMobile: false,
-      isPortrait: false
+      isPortrait: false,
+      auto_reload: true
     });
   };
 
@@ -138,12 +139,12 @@ var FlexDashboard = (function () {
     initPrismHighlighting();
 
     // record mobile and orientation state then register a handler
-    // to refresh if it changes
+    // to refresh if auto_reload is set to true and it changes
     _options.isMobile = isMobilePhone();
     _options.isPortrait = isPortrait();
     $(window).on('resize', function() {
-      if (_options.isMobile !== isMobilePhone() ||
-          _options.isPortrait !== isPortrait()) {
+      if ((_options.isMobile !== isMobilePhone() && _options.auto_reload) ||
+          (_options.isPortrait !== isPortrait() && _options.auto_reload)) {
         window.location.reload();
       }
     });


### PR DESCRIPTION
Updated to reflect suggested changes from rstudio/flexdashboard#246

flex_dashboard.R
 - Rename variable to resize_reload as it's more self-explanatory
- Indent if...else... for YAML parsing consistently

flexdashboard.js
 - Update name
 - encapsulate window resize handler with _options.resize_reload conditional instead of grouped conditional