### PR TITLE
Fix renderText bug for h3 elements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ flexdashboard 0.5.2 (unreleased)
 
 * Support use of Font Awesome icon sets (e.g. "fab fa-r-project")
 
+* Fixed [#245](https://github.com/rstudio/flexdashboard/issues/245): Shiny (1.4.0+) outputs not rendering in modified flexdashboard html. ([#250](https://github.com/rstudio/flexdashboard/pull/250))
+
 
 flexdashboard 0.5.1
 ===========

--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
@@ -261,7 +261,7 @@ var FlexDashboard = (function () {
     if (active)
       wrapper.addClass('active');
 
-    // get a reference to the h1, discover it's id and title, then remove it
+    // get a reference to the h1, discover its inner contens, then detach it
     var h1 = wrapper.find('h1').first();
     var title = h1.contents();
     h1.detach();
@@ -409,7 +409,7 @@ var FlexDashboard = (function () {
       // wipeout h2 elements then enclose them in a single h2
       var level2 = page.find('div.section.level2');
       level2.each(function() {
-        level2.children('h2').detach();
+        level2.children('h2').remove();
         level2.children().unwrap();
       });
       page.wrapInner('<div class="section level2"></div>');
@@ -1667,7 +1667,7 @@ window.FlexDashboardComponents.push({
       chartValue = chartValue.replace("[1] ", "");
       valueOutputSpan = valueBox.find('span.value-output').detach();
       valueBox.children().remove();
-      value.append(chartValue);
+      value.text(chartValue);
     }
 
     // caption

--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
@@ -72,9 +72,9 @@ var FlexDashboard = (function () {
         globalSidebar.addClass('level3');
         var h1 = globalSidebar.children('h1');
         var h3 = $('<h3></h3>');
-        h3.html(h1.html());
+        h3.append(h1.contents());
         h3.insertBefore(h1);
-        h1.remove();
+        h1.detach();
 
         // move it into the first page
         var page = dashboardContainer.find('.section.level1').first();
@@ -263,8 +263,8 @@ var FlexDashboard = (function () {
 
     // get a reference to the h1, discover it's id and title, then remove it
     var h1 = wrapper.find('h1').first();
-    var title = h1.html();
-    h1.remove();
+    var title = h1.contents();
+    h1.detach();
 
     // create a navbar item
     var li = $('<li></li>');
@@ -402,14 +402,14 @@ var FlexDashboard = (function () {
       sidebar.wrapInner('<div class="section level3"></div>');
       var h2 = sidebar.find('h2');
       var h3 = $('<h3></h3>');
-      h3.html(h2.html());
+      h3.append(h2.contents());
       h3.insertBefore(h2);
-      h2.remove();
+      h2.detatch();
 
       // wipeout h2 elements then enclose them in a single h2
       var level2 = page.find('div.section.level2');
       level2.each(function() {
-        level2.children('h2').remove();
+        level2.children('h2').detach();
         level2.children().unwrap();
       });
       page.wrapInner('<div class="section level2"></div>');
@@ -546,8 +546,8 @@ var FlexDashboard = (function () {
       // extract the title from the h3
       var li = $('<li></li>');
       var h3 = frame.children('h3');
-      li.html(h3.html());
-      h3.remove();
+      li.append(h3.contents());
+      h3.detach();
       ul.append(li);
 
       // extract commentary
@@ -943,7 +943,7 @@ var FlexDashboard = (function () {
 
     // add the title
     var chartTitle = $('<div class="chart-title"></div>');
-    chartTitle.html(title);
+    chartTitle.append(title);
     chart.prepend(chartTitle);
 
     // add the notes section
@@ -999,10 +999,11 @@ var FlexDashboard = (function () {
 
       // get the heading element within it and grab it's text
       var heading = tab.find('h' + tabLevel + ':first');
-      var headingText = heading.html();
+      var headingDom = heading.contents();
 
       // build and append the tab list item
-      var a = $('<a role="tab" data-toggle="tab">' + headingText + '</a>');
+      var a = $('<a role="tab" data-toggle="tab"></a>');
+      a.append(headingDom);
       a.attr('href', '#' + id);
       a.attr('aria-controls', id);
       var li = $('<li role="presentation"></li>');
@@ -1125,8 +1126,8 @@ var FlexDashboard = (function () {
     var h3 = container.children('h3').first();
     var title = '';
     if (!container.hasClass('no-title'))
-      title = h3.html();
-    h3.remove();
+      title = h3.contents();
+    h3.detach();
     return title;
   }
 
@@ -1137,11 +1138,11 @@ var FlexDashboard = (function () {
     var caption = chartContent.children('div.image-container')
                               .children('p.caption');
     if (blockquote.length) {
-      chartNotes.html(blockquote.children('p:first-child').html());
+      chartNotes.empty().append(blockquote.children('p:first-child').contents());
       blockquote.remove();
       return true;
     } else if (caption.length) {
-      chartNotes.html(caption.html());
+      chartNotes.empty().append(caption.contents());
       caption.remove();
       return true;
     } else {
@@ -1666,12 +1667,12 @@ window.FlexDashboardComponents.push({
       chartValue = chartValue.replace("[1] ", "");
       valueOutputSpan = valueBox.find('span.value-output').detach();
       valueBox.children().remove();
-      value.text(chartValue);
+      value.append(chartValue);
     }
 
     // caption
     var caption = $('<p class="caption"></p>');
-    caption.html(chartTitle);
+    caption.append(chartTitle);
 
     // build inner div for value box and add it
     var inner = $('<div class="inner"></div>');
@@ -1772,5 +1773,3 @@ window.FlexDashboardComponents.push({
     );
   }
 });
-
-


### PR DESCRIPTION
Fixes #245

~~There was a timing issue with how shiny initialized.  Because titles were shuffled around, shiny said it looked like a `shiny-bound-output` class object, but it didn't have the proper information.~~

~~`$(document).ready()` is not needed as the JS is sourced at end of body and the Flexdashboard code is sourced at the beginning of the body.  So the `setTimeout` can be dropped from https://github.com/rstudio/flexdashboard/commit/acf013d6ef58634e9283e54e5c8a18d48e8cc03b~~

-----------------------

~~Have tried on Shiny 1.4+ and Shiny 1.3.2.  (The issue was created when jQuery was bumped to v3. See https://github.com/rstudio/flexdashboard/issues/245#issuecomment-567207986)~~