### PR TITLE
Decode URI component when retrieving the location hash

### DIFF
--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
@@ -1202,14 +1202,14 @@ var FlexDashboard = (function () {
   function handleLocationHash() {
 
     // restore tab/page from bookmark
-    var hash = window.location.hash;
+    var hash = window.decodeURIComponent(window.location.hash);
     if (hash.length > 0)
       $('ul.nav a[href="' + hash + '"]').tab('show');
     FlexDashboardUtils.manageActiveNavbarMenu();
 
     // navigate to a tab when the history changes
     window.addEventListener("popstate", function(e) {
-      var hash = window.location.hash;
+      var hash = window.decodeURIComponent(window.location.hash);
       var activeTab = $('ul.nav a[href="' + hash + '"]');
       if (activeTab.length) {
         activeTab.tab('show');


### PR DESCRIPTION
Bug from https://community.rstudio.com/t/problem-with-using-cyrillic-letters-in-url-in-shinyapps-io/53683

Fix similar to https://github.com/rstudio/learnr/pull/330/files#diff-abbe664e59e1f3b0778136e73f02cc34R323

~~(Currently Untested)~~ * Tested. Works.
