### PR TITLE
Fix detach call and Fix css height when not reloading on resize

### DIFF
--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
@@ -398,13 +398,15 @@ var FlexDashboard = (function () {
       // if there is a sidebar we need to ensure it's content
       // is properly framed as an h3
       var sidebar = page.find('.section.sidebar');
-      sidebar.removeClass('sidebar');
-      sidebar.wrapInner('<div class="section level3"></div>');
-      var h2 = sidebar.find('h2');
-      var h3 = $('<h3></h3>');
-      h3.append(h2.contents());
-      h3.insertBefore(h2);
-      h2.detatch();
+      if (sidebar.length > 0) {
+        sidebar.removeClass('sidebar');
+        sidebar.wrapInner('<div class="section level3"></div>');
+        var h2 = sidebar.find('h2');
+        var h3 = $('<h3></h3>');
+        h3.append(h2.contents());
+        h3.insertBefore(h2);
+        h2.detatch();
+      }
 
       // wipeout h2 elements then enclose them in a single h2
       var level2 = page.find('div.section.level2');

--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
@@ -149,6 +149,18 @@ var FlexDashboard = (function () {
           window.location.reload();
         }
       });
+    } else {
+      // if in desktop mode and resizing to mobile, make sure the heights are 100%
+      // This enforces what `fillpage.css` does for "wider" pages.
+      // Since we are not reloading once the page becomes small, we need to force the height to 100%
+      // This is a new situation introduced when `_options.resize_reload` is `false`
+      if (! _options.isMobile) {
+        // only add if `fillpage.css` was added in the first place
+        if (_options.fillPage) {
+          // fillpage.css
+          $("html,body,#dashboard").css("height", "100%");
+        }
+      }
     }
     // trigger layoutcomplete event
     dashboardContainer.trigger('flexdashboard:layoutcomplete');

--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
@@ -410,15 +410,13 @@ var FlexDashboard = (function () {
       // if there is a sidebar we need to ensure it's content
       // is properly framed as an h3
       var sidebar = page.find('.section.sidebar');
-      if (sidebar.length > 0) {
-        sidebar.removeClass('sidebar');
-        sidebar.wrapInner('<div class="section level3"></div>');
-        var h2 = sidebar.find('h2');
-        var h3 = $('<h3></h3>');
-        h3.append(h2.contents());
-        h3.insertBefore(h2);
-        h2.detatch();
-      }
+      sidebar.removeClass('sidebar');
+      sidebar.wrapInner('<div class="section level3"></div>');
+      var h2 = sidebar.find('h2');
+      var h3 = $('<h3></h3>');
+      h3.append(h2.contents());
+      h3.insertBefore(h2);
+      h2.detach();
 
       // wipeout h2 elements then enclose them in a single h2
       var level2 = page.find('div.section.level2');


### PR DESCRIPTION
* If the sidebar did not have any h2 element to work with, then the `detach` method failed to execute.

* When `resize_reload = false`, the css height of html and body was not set to 100% when moving from desktop to mobile width. This caused the page to collapse to a very short page as the media query was removed.

### Testing app

````md
---
title: "Hello Shiny!"
output: 
  flexdashboard::flex_dashboard:
    orientation: columns
    vertical_layout: fill
    resize_reload: false
runtime: shiny
---

```{r setup, include=FALSE}
library(shiny)
```

Column {data-width=350}
-----------------------------------------------------------------------

### Sidebar - slider

```{r}
sliderInput(inputId = "bins",
                  label = "Number of bins:",
                  min = 1,
                  max = 50,
                  value = 30)
```

Column {data-width=650}
-----------------------------------------------------------------------

### Bins

```{r}
renderPrint({
  input$bins
})
```
````