### PR TITLE
Add padding to top of sidebar

### DIFF
--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.css
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.css
@@ -596,6 +596,7 @@ body hr {
   bottom: 0;
   border-right: 1px solid #e2e2e2;
   background-color: white; /* overridden by theme */
+  padding-top: 10px;
   padding-left: 10px;
   padding-right: 10px;
   visibility: hidden;


### PR DESCRIPTION
This should fix rstudio/shinycoreci-apps#90.

It now looks like this:
![image](https://user-images.githubusercontent.com/86978/103949904-987bcf00-5101-11eb-89f6-7bb1eb9c0143.png)
