### PR TITLE
Add support for {.active} class within {.tabset}s

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@ flexdashboard 0.5.2.9000
 
 ### Improvements & fixes
 
+* Closed #310: An `.active` class may now be added to a particular `.tabset` tab to control which tab is shown by default. (#311)
+
 * Closed #306: A `.tabset-pills` class may now be added to `.tabset` to render pills instead of tabs. (#307)
 
 * Closed #297, #254: `gauge()` now uses justgage.js 1.4.0, allowing  `renderGauge()` to properly update various labels and `sectors` on redraw. (#301)

--- a/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
+++ b/inst/rmarkdown/templates/flex_dashboard/resources/flexdashboard.js
@@ -997,6 +997,7 @@ var FlexDashboard = (function () {
     $(tabs[0]).before(tabContent);
 
     // build the tabset
+    var activeTab = 0;
     tabs.each(function(i) {
 
       // get the tab div
@@ -1004,6 +1005,10 @@ var FlexDashboard = (function () {
 
       // get the id then sanitize it for use with bootstrap tabs
       var id = tab.attr('id');
+
+      // see if this is marked as the active tab
+      if (tab.hasClass('active'))
+        activeTab = i;
 
       // sanitize the id for use with bootstrap tabs
       id = id.replace(/[.\/?&!#<>]/g, '').replace(/\s/g, '_');
@@ -1020,8 +1025,6 @@ var FlexDashboard = (function () {
       a.attr('aria-controls', id);
       var li = $('<li role="presentation"></li>');
       li.append(a);
-      if (i === 0)
-        li.attr('class', 'active');
       tabList.append(li);
 
       // set it's attributes
@@ -1031,15 +1034,17 @@ var FlexDashboard = (function () {
       tab.addClass('no-title');
       if (fade)
         tab.addClass('fade');
-      if (i === 0) {
-        tab.addClass('active');
-        if (fade)
-          tab.addClass('in');
-      }
 
       // move it into the tab content div
       tab.detach().appendTo(tabContent);
     });
+
+    // set active tab
+    $(tabList.children('li')[activeTab]).addClass('active');
+    var active = $(tabContent.children('div.section')[activeTab]);
+    active.addClass('active');
+    if (fade)
+      active.addClass('in');
 
     // add nav-tabs-custom
     tabset.addClass('nav-tabs-custom');


### PR DESCRIPTION
Closes #310 (see there for a minimal testing example)

Note that this logic mirrors very closely [the logic used to power the same feature in `html_document()`](https://github.com/rstudio/rmarkdown/blob/f8c23b6/inst/rmd/h/navigation-1.1/tabsets.js#L79)

