### PR TITLE
Improve valueBox()'s contrasting

### DIFF
--- a/inst/www/flex_dashboard/value-box-sass/accent-dynamic.scss
+++ b/inst/www/flex_dashboard/value-box-sass/accent-dynamic.scss
@@ -6,11 +6,15 @@ $brand-warning: #f0ad4e !default;
 $brand-danger: #d9534f !default;
 $theme-colors: ("primary": $brand-primary, "info": $brand-info, "warning": $brand-warning, "danger": $brand-danger) !default;
 
-// Value boxes use a less saturated version of the actual accent color
-// for their background and the icon uses the actual primary color
 @each $color, $value in $theme-colors {
-  $bg-vb: mix(white, $value, 20%);
-  $fg-vb: color-contrast($bg-vb, #1a1a1a);
+  // Value boxes use a less saturated version of the actual accent color
+  // for their background and the icon uses the actual accent color
+  $bg-vb: rgba($value, 0.7);
+  // Use white as a fg color as long as it provides a 2.5 contrast ratio
+  // (or higher). This value was chosen so that we get a white fg
+  // against the primary accent bg color (to match RStudio branding)
+  $min-contrast-ratio: 2.5;
+  $fg-vb: color-contrast(opaque($body-bg, $bg-vb), white);
 
   .value-box.value-box-#{$color} {
     background-color: $bg-vb;

--- a/tools/updateValueBox.R
+++ b/tools/updateValueBox.R
@@ -2,10 +2,10 @@ library(sass)
 pkg_dir <- rprojroot::find_package_root_file()
 pkgload::load_all(pkg_dir) # To load themeColors
 
-resources <- file.path(pkg_dir, "inst/rmarkdown/templates/flex_dashboard/resources/")
+flex_home <- file.path(pkg_dir, "inst/www/flex_dashboard")
 
 # Compile CSS the 'core' CSS for viewBox()
-withr::with_dir(resources, {
+withr::with_dir(flex_home, {
   sass(
     sass_file("value-box-sass/core.scss"),
     output = "value-box.css",
@@ -16,7 +16,7 @@ withr::with_dir(resources, {
 # Compile a different CSS for each theme to facilitate viewBox()'s accent colors
 for (theme in names(themeColors)) {
   colors <- themeColors[[theme]]
-  withr::with_dir(resources, {
+  withr::with_dir(flex_home, {
     sass(
       list(
         sprintf(


### PR DESCRIPTION
This PR makes it so `valueBox()` prefers a white contrast (as long it provides a contrast ratio of 2.5 or higher) when using `{bslib}`. As a result, by default with `version: 4` (i.e., if you haven't customized the `primary` color), you'll now see:

````
---
output: 
  flexdashboard::flex_dashboard:
    theme:
      version: 4
---

```{r}
valueBox(1, caption = "primary", icon = "fa-github")
```
````

<img width="435" alt="Screen Shot 2021-04-15 at 5 13 03 PM" src="https://user-images.githubusercontent.com/1365941/114944838-ef362a80-9e0d-11eb-8025-3d971430b99d.png">

Instead of 

<img width="427" alt="Screen Shot 2021-04-15 at 5 13 36 PM" src="https://user-images.githubusercontent.com/1365941/114944865-f9f0bf80-9e0d-11eb-8d2d-187b28406ee6.png">
