### PR TITLE
Fix gha

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -59,21 +59,12 @@ jobs:
         run: pkgdown::build_site(new_process = FALSE)
         shell: Rscript {0}
 
-      - name: Git setup
-        run: |
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-
-      - name: Deploy package
-        run: pkgdown::deploy_to_branch(new_process = FALSE)
-        shell: Rscript {0}
-
       - name: Deploy to Netlify
         id: netlify-deploy
         uses: nwtgck/actions-netlify@v1.1
         # NETLIFY_AUTH_TOKEN added in the repo's secrets
         with:
-          publish-dir: 'docs'
+          publish-dir: 'reference'
           production-branch: master
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 .*.Rnb.cached
 sandbox/
+reference


### PR DESCRIPTION
Hi @cpsievert - this should fix the pkgdown build error. To fully restore the `quillt` GHA, you can use:

`quillt::use_github_action_quillt_pkgdown()`