### PR TITLE
Update example of using module with flexdashboard

### DIFF
--- a/vignettes/snippets/shinyembeddedmodule.md
+++ b/vignettes/snippets/shinyembeddedmodule.md
@@ -12,9 +12,11 @@ worldPhonesUI <- function(id) {
 }
 
 # Server function
-worldPhones <- function(input, output, session) {
-  output$phonePlot <- renderPlot({
-    barplot(WorldPhones[,input$region]*1000, 
-            ylab = "Number of Telephones", xlab = "Year")
+worldPhones <- function(id) {
+  moduleServer(id, function(input, output, session) {
+    output$phonePlot <- renderPlot({
+      barplot(WorldPhones[, input$region] * 1000,
+              ylab = "Number of Telephones", xlab = "Year")
+    })
   })
 }

--- a/vignettes/snippets/shinyembeddedmodulecall.md
+++ b/vignettes/snippets/shinyembeddedmodulecall.md
@@ -4,5 +4,5 @@ source("worldPhones.R")
 
 # call the module
 worldPhonesUI("phones")
-callModule(worldPhones, "phones")
+worldPhones("phones")
 ```


### PR DESCRIPTION
Closes #275 

This PR updated the example code demonstrating the use a [Shiny module](https://pkgs.rstudio.com/flexdashboard/articles/shiny.html#shiny-modules-1) with `flexdashboard.` Currently, this example uses the old `callModule()` paradigm which I believe was superseded by the `moduleServer()` paradigm as of [Shiny 1.5](https://shiny.rstudio.com/articles/modules.html#migrating-from-callmodule-to-moduleserver) to use the `moduleServer()` paradigm instead.