### PR TITLE
Add HEAD placeholder in html template for shiny_prerendered

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ This release adds integration with the new [`{bslib}` package](https://rstudio.g
 
 ### Improvements & fixes
 
+* Close #343: Fix an issue with order of dependencies with `shiny_prerendered` following previous changes in rmarkdown - rstudio/rmarkdown#2064. (#344)  
+
 * Closed #315, #321, and #286: `DT::datatable()` now fills its container correctly inside of `flexdashboard::flex_dashboard()`. (#322) 
 
 * Closed #310: An `.active` class may now be added to a particular `.tabset` tab to control which tab is shown by default. (#311)

--- a/inst/www/flex_dashboard/default.html
+++ b/inst/www/flex_dashboard/default.html
@@ -35,6 +35,9 @@ window.FlexDashboardComponents = [];
 $for(header-includes)$
 $header-includes$
 $endfor$
+$if(shiny-prerendered)$
+<!-- HEAD_CONTENT -->
+$endif$
 
 $if(devel)$
 <link rel="stylesheet" href="../rmarkdown/templates/flex_dashboard/resources/flexdashboard.css" type="text/css" />


### PR DESCRIPTION
It should fix #343 

This follows changes in 

* rstudio/rmarkdown#1942 where we fix a long standing issue with how HTML content was added in shinyapps UI with `shiny_prerendered` 
* then rstudio/rmarkdown#2064 which complement the previous one by offering a way to get the html dependencies in the correct order in the HTML template. 

I should have thought to update the template in flexdashboard following this change.

It could be a good idea to update the rmarkdown requirement to `>= 2.8` but it may not be necessary for this to work. It is the other way around: if you have rmarkdown 2.8 or above you need this version of flexdashboard. Not sure we can do it in this way. If you don't see an issue, I would bump the requirement. (which you may need to do already for bslib support) 