### PR TITLE
Make gauge()'s overflowing svg content visible

### DIFF
--- a/inst/htmlwidgets/lib/justgage/justgage.css
+++ b/inst/htmlwidgets/lib/justgage/justgage.css
@@ -6,4 +6,5 @@
   height: 110px;
   margin-top: 5px;
   margin-bottom: -10px;
+  overflow: visible !important;
 }

--- a/man/flex_dashboard.Rd
+++ b/man/flex_dashboard.Rd
@@ -136,7 +136,7 @@ bootstrap, etc.) into. By default this will be the name of the document with
 \code{_files} appended to it.}
 
 \item{md_extensions}{Markdown extensions to be added or removed from the
-default definition or R Markdown. See the \code{\link[rmarkdown]{rmarkdown_format}} for
+default definition of R Markdown. See the \code{\link[rmarkdown]{rmarkdown_format}} for
 additional details.}
 
 \item{pandoc_args}{Additional command line options to pass to pandoc}


### PR DESCRIPTION
Closes #388

## Testing notes

Install `remotes::install_github("rstudio/flexdashboard")`, then ensure `Line 2` is visible under `Line 1` in the following example app:

```r
library(shiny)
library(flexdashboard)

ui <- fluidPage(
  column(12, gaugeOutput("gauge1")),
  column(12, gaugeOutput("gauge2"))
)

server <- function(input, output) {
  
  output$gauge1 <- renderGauge({
    gauge(15, min=0, max=100, label="Line 1\n Line2")
  })
  
  output$gauge2 <- renderGauge({
    gauge(25, min=0, max=100, label="Line 1\n Line2")
  }) 
}

shinyApp(ui = ui, server = server)
```