### PR TITLE
Reposition navbar-logo to the left

### DIFF
--- a/inst/www/flex_dashboard/default.html
+++ b/inst/www/flex_dashboard/default.html
@@ -59,7 +59,7 @@ $endfor$
 <div class="container-fluid">
 <div class="navbar-header">
 
-<span class="navbar-logo">
+<span class="navbar-logo pull-left">
   $if(logo)$<img src="$logo$" class="navbar-logo"/>$endif$
 </span>
 <span class="navbar-brand">


### PR DESCRIPTION
Per issue #398 

The "pull-left" class was removed from the logo in a previous commit. I'm simply adding it back that way I can take advantage of the new version.

Disclaimer: this is my first PR of an open sourced project. If I did something incorrect please let me know. I appreciate the feedback.