### PR TITLE
Fix active nav menu markup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # flexdashboard 0.6.1.9000
 
-
+* Fixed #411: Improved support for Bootstrap 5 to ensure correct handling of the active dashboard page. (#418)
 
 # flexdashboard 0.6.1
 

--- a/inst/www/flex_dashboard/flexdashboard.js
+++ b/inst/www/flex_dashboard/flexdashboard.js
@@ -1229,7 +1229,6 @@ var FlexDashboard = (function () {
     var hash = window.decodeURIComponent(window.location.hash);
     if (hash.length > 0)
       $('ul.nav a[href="' + hash + '"]').tab('show');
-    FlexDashboardUtils.manageActiveNavbarMenu();
 
     // navigate to a tab when the history changes
     window.addEventListener("popstate", function(e) {
@@ -1240,7 +1239,6 @@ var FlexDashboard = (function () {
       } else {
         $('ul.nav a:first').tab('show');
       }
-      FlexDashboardUtils.manageActiveNavbarMenu();
     });
 
     // add a hash to the URL when the user clicks on a tab/page
@@ -1248,6 +1246,8 @@ var FlexDashboard = (function () {
       var baseUrl = FlexDashboardUtils.urlWithoutHash(window.location.href);
       var hash = FlexDashboardUtils.urlHash($(this).attr('href'));
       var href = baseUrl + hash;
+      // the BS tab plugin handles changing the page and managing the navbar
+      // but flexdashboard needs to update the location and history
       FlexDashboardUtils.setLocation(href);
     });
 
@@ -1324,7 +1324,6 @@ window.FlexDashboardUtils = {
     setTimeout(function() {
         window.scrollTo(0, 0);
     }, 10);
-    this.manageActiveNavbarMenu();
   },
   showPage: function(href) {
     $('ul.navbar-nav li a[href="' + href + '"]').tab('show');
@@ -1352,17 +1351,6 @@ window.FlexDashboardUtils = {
       return url.substring(hashLoc);
     else
       return "";
-  },
-  manageActiveNavbarMenu: function () {
-    // remove active from currently active tabs
-    $('.navbar ul.nav .active').removeClass('active');
-    // find the active tab
-    var activeTab = $('.dashboard-page-wrapper.tab-pane.active');
-    if (activeTab.length > 0) {
-      var tabId = activeTab.attr('id');
-      if (tabId)
-        $(".navbar ul.nav a[href='#" + tabId + "']").tab("show");
-    }
   }
 };
 

--- a/inst/www/flex_dashboard/flexdashboard.js
+++ b/inst/www/flex_dashboard/flexdashboard.js
@@ -299,6 +299,10 @@ var FlexDashboard = (function () {
       container.append(li);
     }
 
+    if (active) {
+      li.addClass('active');
+    }
+
     // hide it if requested
     if (hidden)
       li.addClass('hidden');

--- a/inst/www/flex_dashboard/flexdashboard.js
+++ b/inst/www/flex_dashboard/flexdashboard.js
@@ -1227,8 +1227,10 @@ var FlexDashboard = (function () {
 
     // restore tab/page from bookmark
     var hash = window.decodeURIComponent(window.location.hash);
-    if (hash.length > 0)
+    if (hash.length > 0) {
+      // Update the tab without .showPage() so that we don't change page history
       $('ul.nav a[href="' + hash + '"]').tab('show');
+    }
 
     // navigate to a tab when the history changes
     window.addEventListener("popstate", function(e) {
@@ -1237,6 +1239,7 @@ var FlexDashboard = (function () {
       if (activeTab.length) {
         activeTab.tab('show');
       } else {
+        // returning to the base page URL without a hash activates first tab
         $('ul.nav a:first').tab('show');
       }
     });

--- a/inst/www/flex_dashboard/flexdashboard.js
+++ b/inst/www/flex_dashboard/flexdashboard.js
@@ -1249,8 +1249,6 @@ var FlexDashboard = (function () {
       var baseUrl = FlexDashboardUtils.urlWithoutHash(window.location.href);
       var hash = FlexDashboardUtils.urlHash($(this).attr('href'));
       var href = baseUrl + hash;
-      // the BS tab plugin handles changing the page and managing the navbar
-      // but flexdashboard needs to update the location and history
       FlexDashboardUtils.setLocation(href);
     });
 

--- a/inst/www/flex_dashboard/flexdashboard.js
+++ b/inst/www/flex_dashboard/flexdashboard.js
@@ -273,8 +273,6 @@ var FlexDashboard = (function () {
 
     // add the tab-pane class to the wrapper
     wrapper.addClass('tab-pane');
-    if (active)
-      wrapper.addClass('active');
 
     // get a reference to the h1, discover its inner contens, then detach it
     var h1 = wrapper.find('h1').first();
@@ -299,7 +297,9 @@ var FlexDashboard = (function () {
       container.append(li);
     }
 
+    // mark active tab and corresponding nav menu item
     if (active) {
+      wrapper.addClass('active');
       li.addClass('active');
     }
 

--- a/inst/www/flex_dashboard/flexdashboard.js
+++ b/inst/www/flex_dashboard/flexdashboard.js
@@ -298,10 +298,8 @@ var FlexDashboard = (function () {
     }
 
     // mark active tab and corresponding nav menu item
-    if (active) {
-      wrapper.addClass('active');
-      li.addClass('active');
-    }
+    if (active)
+      $(a).tab("show");
 
     // hide it if requested
     if (hidden)


### PR DESCRIPTION
Fixes #411

This is a minimal fix for the behavior described in #411. The root issue is that BS5 requires a `.tab-pane.active` to have a corresponding `.active` toggle item. I'm being vague because the active class can appear as either `li.nav-item.active` or `.nav-link.active`. When the active class is imbalanced in the markup in BS5, the `.active` class isn't removed from the imbalanced `.tab-pane` until after it's activated.

https://user-images.githubusercontent.com/5420529/220937196-748eb254-4f90-44f0-93b3-46c2736bf4d8.mp4

The clip above uses the markup created by flexdashboard during initialization just [before the Bootstrap tab plugin is invoked](https://github.com/rstudio/flexdashboard/blob/bf8cdc55e15e3a7cfc53ed2d186a9303d271dc48/inst/www/flex_dashboard/flexdashboard.js#L135-L136). You can observe the tab behavior in Bootstrap versions 3-5 using this Rmd:

<details><summary><code>bootstrap-tabs-init.Rmd</code></summary>

````markdown
---
title: BS Nav Test
output:
  html_document:
    theme:
      version: 5
    self_contained: false
---

> Bootstrap version <span id="bs-version">x.y.z</span>

<span id="state">⏱️ before initializing tabs</span>

## No active classes anywhere

```{=html}
<div id="no-active">
  <div class="navbar bg-light navbar-default">
    <ul class="nav navbar-nav navbar-left">
      <li class="nav-item">
        <a class="nav-link" href="#no-active-one" data-toggle="tab">One</a>
      </li>
      <li class="nav-item">
        <a class="nav-link" href="#no-active-two" data-toggle="tab">Two</a>
      </li>
      <li class="nav-item">
        <a class="nav-link" href="#no-active-three" data-toggle="tab">Three</a>
      </li>
    </ul>
  </div>

  <div class="tab-content" style="height: 100%;">
    <div class="dashboard-page-wrapper tab-pane" id="no-active-one" style="height: 100%;">one content</div>
    <div class="dashboard-page-wrapper tab-pane" id="no-active-two" style="height: 100%;">two content</div>
    <div class="dashboard-page-wrapper tab-pane" id="no-active-three" style="height: 100%;">three content</div>
  </div>
</div>
```

## Nav doesn't have active class

```{=html}
<div id="nav-no-class">
  <div class="navbar bg-light navbar-default">
    <ul class="nav navbar-nav navbar-left">
      <li class="nav-item">
        <a class="nav-link" href="#nav-no-class-one" data-toggle="tab">One</a>
      </li>
      <li class="nav-item">
        <a class="nav-link" href="#nav-no-class-two" data-toggle="tab">Two</a>
      </li>
      <li class="nav-item">
        <a class="nav-link" href="#nav-no-class-three" data-toggle="tab">Three</a>
      </li>
    </ul>
  </div>

  <div class="tab-content" style="height: 100%;">
    <div class="dashboard-page-wrapper tab-pane active" id="nav-no-class-one" style="height: 100%;">one content</div>
    <div class="dashboard-page-wrapper tab-pane" id="nav-no-class-two" style="height: 100%;">two content</div>
    <div class="dashboard-page-wrapper tab-pane" id="nav-no-class-three" style="height: 100%;">three content</div>
  </div>
</div>
```

## Nav has active class on li

```{=html}
<div id="nav-class-li">
  <div class="navbar bg-light navbar-default">
    <ul class="nav navbar-nav navbar-left">
      <li class="nav-item active">
        <a class="nav-link" href="#nav-class-li-one" data-toggle="tab">One</a>
      </li>
      <li class="nav-item">
        <a class="nav-link" href="#nav-class-li-two" data-toggle="tab">Two</a>
      </li>
      <li class="nav-item">
        <a class="nav-link" href="#nav-class-li-three" data-toggle="tab">Three</a>
      </li>
    </ul>
  </div>

  <div class="tab-content" style="height: 100%;">
    <div class="dashboard-page-wrapper tab-pane active" id="nav-class-li-one" style="height: 100%;">one content</div>
    <div class="dashboard-page-wrapper tab-pane" id="nav-class-li-two" style="height: 100%;">two content</div>
    <div class="dashboard-page-wrapper tab-pane" id="nav-class-li-three" style="height: 100%;">three content</div>
  </div>
</div>
```

## Nav has active class on li > a

```{=html}
<div id="nav-class-li-a">
  <div class="navbar bg-light navbar-default">
    <ul class="nav navbar-nav navbar-left">
      <li class="nav-item">
        <a class="nav-link active" href="#nav-class-li-a-one" data-toggle="tab">One</a>
      </li>
      <li class="nav-item">
        <a class="nav-link" href="#nav-class-li-a-two" data-toggle="tab">Two</a>
      </li>
      <li class="nav-item">
        <a class="nav-link" href="#nav-class-li-a-three" data-toggle="tab">Three</a>
      </li>
    </ul>
  </div>

  <div class="tab-content" style="height: 100%;">
    <div class="dashboard-page-wrapper tab-pane active" id="nav-class-li-a-one" style="height: 100%;">one content</div>
    <div class="dashboard-page-wrapper tab-pane" id="nav-class-li-a-two" style="height: 100%;">two content</div>
    <div class="dashboard-page-wrapper tab-pane" id="nav-class-li-a-three" style="height: 100%;">three content</div>
  </div>
</div>
```

```{=html}
<button id="activate" class="btn btn-primary" style="position: absolute; bottom: 1em; right: 1em;">activate</button>
```

```{js echo=FALSE}
$(function() {
  const bs_v = $.fn.tab.Constructor.VERSION;
  console.log(`Bootstrap version: ${bs_v}`);
  document.getElementById('bs-version').innerText = bs_v;
})

$('#activate').on('click', function() {
  ['no-active', 'nav-no-class', 'nav-class-li', 'nav-class-li-a']
    .forEach(id => {
      console.log(
        `activating #${id}, active elements:`,
        document.querySelectorAll(`#${id} .active`)
      )
      $(`[href="#${id}-two"]`).tab('show')
    })

  $('#state').text('✅ tabs ready')
})
```

````

</details>

Testing across all the three major versions of Bootstrap reveals that adding the `.active` class to the nav list item maintains consistent appearance and behavior across all versions, even if the tab plugin were to fail for some reason.

| BS | Before | After |
|:--:|:--:|:--:|
| 3 | ![bs3-before](https://user-images.githubusercontent.com/5420529/220939006-03eaec58-6f7f-41c7-b25c-f33eaa0bac0b.png) | ![bs3-after](https://user-images.githubusercontent.com/5420529/220939030-65be7bfa-07f9-4fdd-a066-fe0e07087674.png) |
| 4 | ![bs4-before](https://user-images.githubusercontent.com/5420529/220939085-a566e437-8822-494b-889e-c1cfba587698.png) | ![bs4-after](https://user-images.githubusercontent.com/5420529/220939101-9d0d3519-5733-422b-93c1-8a6f9dd22470.png) |
| 5 | ![bs5-before](https://user-images.githubusercontent.com/5420529/220939179-adfe3590-a580-489d-a321-b1616ca5bdc7.png) | ![bs5-after](https://user-images.githubusercontent.com/5420529/220939194-4334a9e2-72c8-40be-a4f8-f89ae4492da4.png) |