### PR TITLE
Include `data-bs-toggle` attribute on all tabs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fixed #411: Improved support for Bootstrap 5 to ensure correct handling of the active dashboard page. (#418)
 
+* Improved support for page selection in navigation dropdown menus in Bootstrap 5. (#421)
+
 # flexdashboard 0.6.1
 
 * Closed #398: The logo is now positioned to the left (instead of the right) of the title (regression introduced by 0.6.0).

--- a/inst/www/flex_dashboard/flexdashboard.js
+++ b/inst/www/flex_dashboard/flexdashboard.js
@@ -283,6 +283,7 @@ var FlexDashboard = (function () {
     var li = $('<li></li>');
     var a = navbarLink(icon, title, '#' + id);
     a.attr('data-toggle', 'tab');
+    a.attr('data-bs-toggle', 'tab');
     li.append(a);
 
     // add it to the navbar (or navbar menu if specified)
@@ -1026,7 +1027,7 @@ var FlexDashboard = (function () {
       var headingDom = heading.contents();
 
       // build and append the tab list item
-      var a = $('<a role="tab" data-toggle="tab" class="nav-link"></a>');
+      var a = $('<a role="tab" data-toggle="tab" data-bs-toggle="tab" class="nav-link"></a>');
       a.append(headingDom);
       a.attr('href', '#' + id);
       a.attr('aria-controls', id);


### PR DESCRIPTION
Fixes #420
Depends on #411

This PR ensures that we include `data-bs-toggle="tab"` everwhere we also use `data-toggle="tab"`, fixing dropdown tab behavior in the flexdashboard nav bar.

https://user-images.githubusercontent.com/5420529/221264682-e63f9a72-1112-44be-b0b9-897598e3a61e.mp4


