### PR TITLE
Redirect from old article locations to new pkgdown locations

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -80,3 +80,10 @@ reference:
   desc: ~
   contents:
   - flexdashboard
+
+redirects:
+  - ["examples.html", "articles/examples.html"]
+  - ["layouts.html", "articles/layouts.html"]
+  - ["shiny.html", "articles/shiny.html"]
+  - ["theme.html", "articles/theme.html"]
+  - ["using.html", "articles/using.html"]


### PR DESCRIPTION
Fixes #378

Redirects articles that previously lived at `./{name}.html` to their new location at `./articles/{name}.html`.