### PR TITLE
Require knitr 1.30

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
   utils,
   jsonlite,
   htmltools (>= 0.5.1),
-  knitr (>= 1.13),
+  knitr (>= 1.30),
   htmlwidgets (>= 0.6),
   rmarkdown (>= 2.8),
   shiny (>= 0.13),


### PR DESCRIPTION
Follow up to #428 (`knitr::hooks_markdown()` was added to knitr 1.30, which is fairly recent release)