### PR TITLE
Migrate docs from Netlify to GitHub Pages

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,11 +15,6 @@ name: Package checks
 jobs:
   website:
     uses: rstudio/shiny-workflows/.github/workflows/website.yaml@v1
-  website-netlify:
-    uses: rstudio/shiny-workflows/.github/workflows/website-netlify.yaml@v1
-    secrets:
-      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
   routine:
     uses: rstudio/shiny-workflows/.github/workflows/routine.yaml@v1
   R-CMD-check:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -73,4 +73,4 @@ Config/Needs/deploy: dplyr, ggplot2, DT, talgalili/d3heatmap, plotly,
 Config/Needs/website: rstudio/quillt
 Config/testthat/edition: 3
 Encoding: UTF-8
-RoxygenNote: 7.3.3
+Config/roxygen2/version: 8.0.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -71,6 +71,6 @@ Config/Needs/deploy: dplyr, ggplot2, DT, talgalili/d3heatmap, plotly,
     arules, treemap, viridisLite, leaflet, metricsgraphics, rbokeh, readr,
     tidyr, jsonlite, maptools, purrr, maps, hexbin
 Config/Needs/website: rstudio/quillt
+Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Encoding: UTF-8
-Config/roxygen2/version: 8.0.0

--- a/README.Rmd
+++ b/README.Rmd
@@ -8,7 +8,7 @@ output: github_document
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
-# flexdashboard <a href='https://pkgs.rstudio.com/flexdashboard'><img src='man/figures/logo.png' align="right" height="138.5" /></a>
+# flexdashboard <a href='https://rstudio.github.io/flexdashboard'><img src='man/figures/logo.png' align="right" height="138.5" /></a>
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/flexdashboard)](https://CRAN.R-project.org/package=flexdashboard)
@@ -21,21 +21,21 @@ The goal of **flexdashboard** is to make it easy to create interactive dashboard
 
 * Support for a wide variety of components including [htmlwidgets](https://www.htmlwidgets.org); base, lattice, and grid graphics; tabular data; gauges and value boxes; and text annotations.
 
-* Flexible and easy to specify row and column-based [layouts](https://pkgs.rstudio.com/flexdashboard/articles/layouts.html). Components are intelligently re-sized to fill the browser and adapted for display on mobile devices.
+* Flexible and easy to specify row and column-based [layouts](https://rstudio.github.io/flexdashboard/articles/layouts.html). Components are intelligently re-sized to fill the browser and adapted for display on mobile devices.
 
-* [Storyboard](https://pkgs.rstudio.com/flexdashboard/articles/using.html#storyboards-1) layouts for presenting sequences of visualizations and related commentary.
+* [Storyboard](https://rstudio.github.io/flexdashboard/articles/using.html#storyboards-1) layouts for presenting sequences of visualizations and related commentary.
 
 * Optionally use [Shiny](https://shiny.posit.co/) to drive visualizations dynamically.
 
-* Optionally use [bslib](https://rstudio.github.io/bslib/) to easily [customize main colors, fonts, and more](https://pkgs.rstudio.com/flexdashboard/articles/theme.html).
+* Optionally use [bslib](https://rstudio.github.io/bslib/) to easily [customize main colors, fonts, and more](https://rstudio.github.io/flexdashboard/articles/theme.html).
 
-Learn more about **flexdashboard**: <https://pkgs.rstudio.com/flexdashboard>
+Learn more about **flexdashboard**: <https://rstudio.github.io/flexdashboard>
 
 ## Examples
 
-<a href="https://testing-apps.shinyapps.io/flexdashboard-d3heatmap/"><img src="https://pkgs.rstudio.com/flexdashboard/articles/images/htmlwidgets-d3heatmap.png" width=250 height=200 alt="example flexdashboard with d3 heatmap"></img></a>&nbsp;&nbsp;<a href="https://testing-apps.shinyapps.io/flexdashboard-ggplotly/"><img src="https://pkgs.rstudio.com/flexdashboard/articles/images/plotly.png" width=250 height=200 alt="example flexdashboard using ggplotly"></img></a>&nbsp;&nbsp;<a href="https://jjallaire.shinyapps.io/shiny-biclust/"><img src="https://pkgs.rstudio.com/flexdashboard/articles/images/shiny-biclust.png" width=250 height=200 alt="example flexdashboard using Shiny"></img></a>
+<a href="https://testing-apps.shinyapps.io/flexdashboard-d3heatmap/"><img src="https://rstudio.github.io/flexdashboard/articles/images/htmlwidgets-d3heatmap.png" width=250 height=200 alt="example flexdashboard with d3 heatmap"></img></a>&nbsp;&nbsp;<a href="https://testing-apps.shinyapps.io/flexdashboard-ggplotly/"><img src="https://rstudio.github.io/flexdashboard/articles/images/plotly.png" width=250 height=200 alt="example flexdashboard using ggplotly"></img></a>&nbsp;&nbsp;<a href="https://jjallaire.shinyapps.io/shiny-biclust/"><img src="https://rstudio.github.io/flexdashboard/articles/images/shiny-biclust.png" width=250 height=200 alt="example flexdashboard using Shiny"></img></a>
 
-View more examples [here](https://pkgs.rstudio.com/flexdashboard/articles/examples.html).
+View more examples [here](https://rstudio.github.io/flexdashboard/articles/examples.html).
 
 
 ## Installation
@@ -61,7 +61,7 @@ If you are not using RStudio, you can create a new `flexdashboard` R Markdown fi
 
 + `"flex_dashboard"` (basic) and
 
-+ `"flex_dashboard_bslib"` (an example of [theming with `{bslib}`](https://pkgs.rstudio.com/flexdashboard/articles/theme.html)):
++ `"flex_dashboard_bslib"` (an example of [theming with `{bslib}`](https://rstudio.github.io/flexdashboard/articles/theme.html)):
 
 ```{r eval=FALSE}
 rmarkdown::draft("dashboard.Rmd",
@@ -79,4 +79,4 @@ There are two main places to get help with flexdashboard:
 
 ## Code of Conduct
 
-Please note that the **flexdashboard** project is released with a [Contributor Code of Conduct](https://pkgs.rstudio.com/flexdashboard/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.
+Please note that the **flexdashboard** project is released with a [Contributor Code of Conduct](https://rstudio.github.io/flexdashboard/CODE_OF_CONDUCT.html). By contributing to this project, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# flexdashboard <a href='https://pkgs.rstudio.com/flexdashboard'><img src='man/figures/logo.png' align="right" height="138.5" /></a>
+# flexdashboard <a href='https://rstudio.github.io/flexdashboard'><img src='man/figures/logo.png' align="right" height="138.5" /></a>
 
 <!-- badges: start -->
 
@@ -21,11 +21,11 @@ dashboards for R, using R Markdown.
   graphics; tabular data; gauges and value boxes; and text annotations.
 
 - Flexible and easy to specify row and column-based
-  [layouts](https://pkgs.rstudio.com/flexdashboard/articles/layouts.html).
+  [layouts](https://rstudio.github.io/flexdashboard/articles/layouts.html).
   Components are intelligently re-sized to fill the browser and adapted
   for display on mobile devices.
 
-- [Storyboard](https://pkgs.rstudio.com/flexdashboard/articles/using.html#storyboards-1)
+- [Storyboard](https://rstudio.github.io/flexdashboard/articles/using.html#storyboards-1)
   layouts for presenting sequences of visualizations and related
   commentary.
 
@@ -34,17 +34,17 @@ dashboards for R, using R Markdown.
 
 - Optionally use [bslib](https://rstudio.github.io/bslib/) to easily
   [customize main colors, fonts, and
-  more](https://pkgs.rstudio.com/flexdashboard/articles/theme.html).
+  more](https://rstudio.github.io/flexdashboard/articles/theme.html).
 
 Learn more about **flexdashboard**:
-<https://pkgs.rstudio.com/flexdashboard>
+<https://rstudio.github.io/flexdashboard>
 
 ## Examples
 
-<a href="https://testing-apps.shinyapps.io/flexdashboard-d3heatmap/"><img src="https://pkgs.rstudio.com/flexdashboard/articles/images/htmlwidgets-d3heatmap.png" width=250 height=200 alt="example flexdashboard with d3 heatmap"></img></a>  <a href="https://testing-apps.shinyapps.io/flexdashboard-ggplotly/"><img src="https://pkgs.rstudio.com/flexdashboard/articles/images/plotly.png" width=250 height=200 alt="example flexdashboard using ggplotly"></img></a>  <a href="https://jjallaire.shinyapps.io/shiny-biclust/"><img src="https://pkgs.rstudio.com/flexdashboard/articles/images/shiny-biclust.png" width=250 height=200 alt="example flexdashboard using Shiny"></img></a>
+<a href="https://testing-apps.shinyapps.io/flexdashboard-d3heatmap/"><img src="https://rstudio.github.io/flexdashboard/articles/images/htmlwidgets-d3heatmap.png" width=250 height=200 alt="example flexdashboard with d3 heatmap"></img></a>  <a href="https://testing-apps.shinyapps.io/flexdashboard-ggplotly/"><img src="https://rstudio.github.io/flexdashboard/articles/images/plotly.png" width=250 height=200 alt="example flexdashboard using ggplotly"></img></a>  <a href="https://jjallaire.shinyapps.io/shiny-biclust/"><img src="https://rstudio.github.io/flexdashboard/articles/images/shiny-biclust.png" width=250 height=200 alt="example flexdashboard using Shiny"></img></a>
 
 View more examples
-[here](https://pkgs.rstudio.com/flexdashboard/articles/examples.html).
+[here](https://rstudio.github.io/flexdashboard/articles/examples.html).
 
 ## Installation
 
@@ -77,7 +77,7 @@ Markdown file from the R console. Currently there are two `templates`:
 - `"flex_dashboard"` (basic) and
 
 - `"flex_dashboard_bslib"` (an example of [theming with
-  `{bslib}`](https://pkgs.rstudio.com/flexdashboard/articles/theme.html)):
+  `{bslib}`](https://rstudio.github.io/flexdashboard/articles/theme.html)):
 
 ``` r
 rmarkdown::draft("dashboard.Rmd",
@@ -108,5 +108,5 @@ There are two main places to get help with flexdashboard:
 
 Please note that the **flexdashboard** project is released with a
 [Contributor Code of
-Conduct](https://pkgs.rstudio.com/flexdashboard/CODE_OF_CONDUCT.html).
+Conduct](https://rstudio.github.io/flexdashboard/CODE_OF_CONDUCT.html).
 By contributing to this project, you agree to abide by its terms.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,6 +1,6 @@
 destination: reference
 
-url: https://pkgs.rstudio.com/flexdashboard/
+url: https://rstudio.github.io/flexdashboard/
 
 template:
   package: quillt

--- a/man/flexdashboard-package.Rd
+++ b/man/flexdashboard-package.Rd
@@ -33,6 +33,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Garrick Aden-Buie \email{garrick@posit.co} (\href{https://orcid.org/0000-0002-7111-0077}{ORCID})
   \item Carson Sievert \email{carson@posit.co} (\href{https://orcid.org/0000-0002-4958-2844}{ORCID})
   \item Richard Iannone \email{rich@posit.co} (\href{https://orcid.org/0000-0003-3925-190X}{ORCID})
   \item JJ Allaire \email{jj@posit.co}


### PR DESCRIPTION
Migrate the flexdashboard pkgdown site from Netlify to GitHub Pages.

## Changes

- `_pkgdown.yml`: update `url` to `https://rstudio.github.io/flexdashboard/`
- `.github/workflows/R-CMD-check.yaml`: remove `website-netlify` job (and its `NETLIFY_AUTH_TOKEN`/`NETLIFY_SITE_ID` secrets) — the existing `website` job already deploys to `gh-pages` via `pkgdown::deploy_to_branch()`
- `README.Rmd`, `README.md`: update all `pkgs.rstudio.com/flexdashboard` links

The `gh-pages` branch already contains the fully rendered site, so `rstudio.github.io/flexdashboard` is live today. A companion PR to `rstudio/pkgs.rstudio.com` will change the `pkgs.rstudio.com/flexdashboard` proxy to a 301 redirect to the new URL.