### PR TITLE
fix: install archived CRAN packages from GitHub for shinyapps.io deploy job

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: rstudio/shiny-workflows/setup-r-package@v1
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,10 +66,10 @@ Imports:
 Suggests:
     testthat
 Config/Needs/deploy: dplyr, ggplot2, DT, talgalili/d3heatmap, plotly,
-    plyr, biclust, webshot, bit, jcheng5/bubbles, digest,
+    plyr, Biclustering/biclust, webshot, bit, jcheng5/bubbles, digest,
     hadley/shinySignals, dygraphs, quantmod, forecast, highcharter,
-    arules, treemap, viridisLite, leaflet, metricsgraphics, rbokeh, readr,
-    tidyr, jsonlite, maptools, purrr, maps, hexbin
+    arules, treemap, viridisLite, leaflet, hrbrmstr/metricsgraphics,
+    hafen/rbokeh, readr, tidyr, jsonlite, purrr, maps, hexbin
 Config/Needs/website: rstudio/quillt
 Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3

--- a/examples/12_leaflet-waste/dashboard.Rmd
+++ b/examples/12_leaflet-waste/dashboard.Rmd
@@ -12,7 +12,6 @@ output:
 library(flexdashboard)
 library(shiny)
 library(jsonlite)
-library(maptools)
 library(ggplot2)
 library(tidyr)
 library(dplyr)


### PR DESCRIPTION
Closes #464

The "Deploy to shinyapps.io" CI job has been failing on every push to `main` because `pak` cannot resolve four packages that were archived or removed from CRAN.

**Changes:**

- `DESCRIPTION` (`Config/Needs/deploy`): replace three CRAN package names with their GitHub equivalents so `pak` can install them:
  - `biclust` → `Biclustering/biclust`
  - `metricsgraphics` → `hrbrmstr/metricsgraphics`
  - `rbokeh` → `hafen/rbokeh`
  - `maptools` removed (retired from CRAN with no maintained GitHub source)

- `examples/12_leaflet-waste/dashboard.Rmd`: remove `library(maptools)` — it was an unused import (the example uses `leaflet` and `plotly` directly, not `maptools`)

- `.github/workflows/R-CMD-check.yaml`: bump `actions/checkout@v2` → `@v4` in the deploy step (was left behind from earlier updates)